### PR TITLE
fix typo

### DIFF
--- a/5.0/controllers.md
+++ b/5.0/controllers.md
@@ -229,7 +229,7 @@ async create(@Body() createCatDto: CreateCatDto) {
 > cats.controller.ts
 
 ```typescript
-import { Controller, Get, Post, Body, Put, Param, Delete } from '@nestjs/common';
+import { Controller, Get, Query, Post, Body, Put, Param, Delete } from '@nestjs/common';
 
 @Controller('cats')
 export class CatsController {


### PR DESCRIPTION
- `5.0 - controllers.md`
- decorator `@Query` was used by func `findAll`, but it's not imported