### PR TITLE
chore: Remove "@types/socket.io" of websockets.md

### DIFF
--- a/8/websockets.md
+++ b/8/websockets.md
@@ -16,7 +16,6 @@
 
 ```bash
 $ npm i --save @nestjs/websockets @nestjs/platform-socket.io
-$ npm i --save-dev @types/socket.io
 ```
 
 ### 概述


### PR DESCRIPTION
```
deprecated @types/socket.io@3.0.2: This is a stub types definition. socket.io provides its own type definitions, so you do not need this installed.
```