### PR TITLE
microservices 中 redis 的使用版本

### DIFF
--- a/8/microservices.md
+++ b/8/microservices.md
@@ -303,6 +303,7 @@ this.client
 ```
 $ npm i --save redis
 ```
+> ps：如果你的 `redis` 无法使用，请尝试使用 `redis@^3`
 
 ### 概述
 


### PR DESCRIPTION
我是一个新手，我尝试使用文档中 `Redis` 的例子，它停止运行了。
我去看了英文的文档，发现了 `(note as of now the supported Redis version is ^3, not the latest ^4)` 
所以我尝试补充这一点。