### PR TITLE
docs: fill in the missing translation

### DIFF
--- a/9/firststeps.md
+++ b/9/firststeps.md
@@ -210,6 +210,8 @@ bootstrap();
 
 请注意，使用 Nest CLI 搭建的项目会创建一个初始项目结构，我们鼓励开发人员将每个模块保存在自己的专用目录中。
 
+?> 默认情况下，如果在创建应用程序时发生了任何错误，你的应用程序会退出并返回错误代码 `1`。如果你想让它抛出错误，请禁用 `abortOnError` 选项(例如，`NestFactory.create(AppModule, { abortOnError: false })`)。
+
 ## 平台
 
 Nest 旨在成为一个与平台无关的框架。 由于平台无关性，我们以创建可重用的逻辑组件，开发人员可以跨越多种不同类型的应用程序来使用这些组件。 从技术上讲，创建了适配器以后，Nest 可以与任何 node.js 的 HTTP 框架一起工作。有两个支持开箱即用的 HTTP 平台：[express](https://expressjs.com/) 和 [fastify](https://www.fastify.io/)。您可以选择最适合您需求的产品。


### PR DESCRIPTION
官方文档的[Overview: First steps](https://docs.nestjs.com/first-steps#setup)章节的Setup标题处的最末尾部分，有一个HINT提示未翻译。将其翻译并补上。