### PR TITLE
fix: 示例代码和官网保持一致

### DIFF
--- a/9/customdecorators.md
+++ b/9/customdecorators.md
@@ -99,7 +99,7 @@ async findOne(@User('firstName') firstName: string) {
 
 ```typescript
 @Get()
-async findOne(@User(new ValidationPipe()) user: UserEntity) {
+async findOne(@User(new ValidationPipe({ validateCustomDecorators: true })) user: UserEntity) {
   console.log(user);
 }
 ```


### PR DESCRIPTION
在自定义装饰器这一小节中，发现示例代码和官网不一致