### PR TITLE
fix: detect stale source in --no-ai translation mode

### DIFF
--- a/scripts/translate-docs.ts
+++ b/scripts/translate-docs.ts
@@ -266,7 +266,16 @@ class DocumentTranslator {
         translatedContent = await this.translateWithAI(content, relativePath);
       } else if (fs.existsSync(outputPath)) {
         const existingContent = fs.readFileSync(outputPath, 'utf8');
-        translatedContent = hasChineseContent(existingContent) ? existingContent : content;
+        const sourceHash = contentHash(content);
+        const cached = this.cache.get(relativePath, sourceHash);
+        if (cached) {
+          console.log(`  Cached (no-ai), keeping existing: ${relativePath}`);
+          translatedContent = existingContent;
+        } else {
+          console.log(`  Source changed (no-ai), using new source: ${relativePath}`);
+          translatedContent = content;
+          this.cache.set(relativePath, sourceHash, '__no-ai__');
+        }
       } else {
         translatedContent = content;
       }


### PR DESCRIPTION
## Problem

The `--no-ai` path in `translate-docs.ts` unconditionally reuses old Chinese translations when they exist, even when the upstream source file has changed. This causes upstream content changes (e.g. `null` -> `undefined` in caching.md) to be silently dropped from the published docs.

## Fix

Replace the unconditional reuse logic with a content-hash-based cache check:

- Compute `contentHash` of the preprocessed source file
- If the cache has a record for this exact source version, keep the existing translation
- If no cache record exists (new or changed source), use the new source file
- Write a cache entry so subsequent runs can detect unchanged sources

This ensures:
- **CI without AI key**: cache is cleared each run, so new source always overrides stale translations
- **Local development**: cache persists, unchanged sources correctly preserve Chinese translations
- **First run after cache clear**: always uses new source (correct, since we cannot verify translation freshness without AI)

## Test Results

Three scenarios verified with `bun scripts/translate-docs.ts --no-ai --force`:

1. Source changed (cache miss) -> correctly overrides with new source
2. Source unchanged (cache hit) -> correctly preserves existing translation  
3. Cache cleared (CI scenario) -> correctly overrides with new source