### PR TITLE
fix(scripts): 修复翻译管线被静默终止的 bug + 支持手动触发全量翻译

### DIFF
--- a/.github/workflows/sync-official-docs.yml
+++ b/.github/workflows/sync-official-docs.yml
@@ -6,6 +6,12 @@ on:
     - cron: '0 2 * * *'
   workflow_dispatch:
     # 允许手动触发
+    inputs:
+      force_translation:
+        description: '强制重新翻译 docs/（即使 content/ 无变更）'
+        type: boolean
+        default: false
+        required: false
 
 jobs:
   sync-docs:
@@ -166,7 +172,7 @@ jobs:
 
       - name: Process and translate content changes
         id: translate-content
-        if: steps.sync-content.outputs.content_changed == 'true'
+        if: steps.sync-content.outputs.content_changed == 'true' || inputs.force_translation == true
         run: |
           echo "🔄 正在处理内容变更并进行翻译..."
           

--- a/scripts/fix-code-blocks.ts
+++ b/scripts/fix-code-blocks.ts
@@ -11,6 +11,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { glob } from 'glob';
 
 const DOCS_DIR = path.resolve(process.cwd(), 'docs');
@@ -92,4 +93,12 @@ async function main() {
   }
 }
 
-main();
+// 仅在直接执行本脚本时运行 CLI 入口。
+// 重要：本文件被 translate-docs.ts 等 模块 import 复用 fixCodeBlocks 函数，
+// 顶层执行 main() 会在宿主进程翻译过程中触发 process.exit()，导致翻译被静默终止。
+const isDirectExecution =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isDirectExecution) {
+  main();
+}


### PR DESCRIPTION
## 问题

自 2026-06-01（d8be370）起，`translate-docs.ts` import 了 `fix-code-blocks.ts`，而后者自 3 月起在模块顶层调用 `main()` 并在其中 `process.exit(0)`。

**后果**：每次同步工作流的翻译步骤启动 ~30ms 后即被 `process.exit(0)` 静默杀死（退出码 0，工作流误报“翻译完成”）。CI 日志证据（run 33726238233）：

```
07:04:21.368  $ bun scripts/translate-docs.ts --verbose
07:04:21.418  🤖 Translating: introduction.md
07:04:21.420  🤖 Translating: controllers.md (chunk 1/5)
07:04:21.432  ✅ Fixed code blocks in 0 files   ← import 副作用完成，process.exit(0)
07:04:21.433  ✅ 翻译完成，有内容更新             ← 无翻译汇总，进程已死
```

导致 `docs/` 中文翻译自 2026-05-04 起停滞，上游 NestJS v12 内容（含全新 observability 章节）无中文。

## 修复

1. **fix-code-blocks.ts**：`main()` 仅在直接执行时运行（`import.meta.url === pathToFileURL(argv[1])` 判断，兼容 bun/tsx）
2. **sync-official-docs.yml**：新增 `workflow_dispatch` 输入 `force_translation`，content/ 无变更时也可手动触发全量重翻译

## 验证

- ✅ bun/tsx 直接执行正常（daily fix 工作流不受影响）
- ✅ 模块 import 进程存活、导出完好
- ✅ YAML 语法校验通过