### PR TITLE
fix(scripts): 更新 NVIDIA NIM 模型 ID（deepseek-v3_1 已下线）

### DIFF
--- a/scripts/lib/ai.ts
+++ b/scripts/lib/ai.ts
@@ -24,7 +24,7 @@ export class AIClient {
     this.config = {
       apiKey: config.apiKey || process.env.NVIDIA_API_KEY || '',
       baseUrl: config.baseUrl || 'https://integrate.api.nvidia.com/v1/chat/completions',
-      model: config.model || 'deepseek-ai/deepseek-v3_1',
+      model: config.model || 'deepseek-ai/deepseek-v4-flash-0731',
       maxTokens: config.maxTokens || 4096,
       temperature: config.temperature || 0.3,
       rpmLimit: config.rpmLimit || 40,

--- a/scripts/translate-docs.ts
+++ b/scripts/translate-docs.ts
@@ -65,7 +65,7 @@ class DocumentTranslator {
 
     this.aiClient = new AIClient({
       apiKey: options.apiKey || process.env.NVIDIA_API_KEY,
-      model: options.model || 'deepseek-ai/deepseek-v3_1',
+      model: options.model || 'deepseek-ai/deepseek-v4-flash-0731',
       maxTokens: options.maxTokens || 4096,
     });
 
@@ -385,7 +385,7 @@ if (args.includes('--help') || args.includes('-h')) {
 选项:
   --content-dir <dir>     源文件目录 (默认: content)
   --docs-dir <dir>        目标文件目录 (默认: docs)
-  --model <model>         NVIDIA NIM 模型 (默认: deepseek-ai/deepseek-v3_1)
+  --model <model>         NVIDIA NIM 模型 (默认: deepseek-ai/deepseek-v4-flash-0731)
   --concurrency <num>     并发请求数 (默认: 3, 受 40 RPM 限速)
   --api-key <key>         NVIDIA API Key (或设置 NVIDIA_API_KEY 环境变量)
   --no-ai                 禁用 AI 翻译，仅处理格式
@@ -405,7 +405,7 @@ const options: Partial<TranslatorOptions> = {
   contentDir: getArgValue('--content-dir') || 'content',
   docsDir: getArgValue('--docs-dir') || 'docs',
   useAI: !args.includes('--no-ai'),
-  model: getArgValue('--model') || 'deepseek-ai/deepseek-v3_1',
+  model: getArgValue('--model') || 'deepseek-ai/deepseek-v4-flash-0731',
   concurrency: concurrencyValue ? parseInt(concurrencyValue, 10) : 3,
   translateEnglish: args.includes('--translate-english'),
   force: args.includes('--force'),


### PR DESCRIPTION
## 问题

修复翻译管线终止 bug 后（#563）触发全量翻译（run 33743077780），136 个文件全部报错：

```
❌ Translation failed for content/introduction.md: API error (404): 404 page not found
```

## 诊断

- `POST https://integrate.api.nvidia.com/v1/chat/completions`（模型 `deepseek-ai/deepseek-v3_1`）→ 404 page not found（无凭证同样 404？否——见下）
- `GET /v1/models` → 200，模型目录中 **`deepseek-v3_1` 已不存在**，已被 v4 系列取代
- `POST /v1/chat/completions` + `deepseek-ai/deepseek-v4-flash-0731` → **401 missing authorization**（路径✓ 模型✓，仅差凭证）

结论：NVIDIA NIM 下线了旧模型 ID，未知模型返回纯文本 404。

## 修复

默认模型更新为 `deepseek-ai/deepseek-v4-flash-0731`（v3.1 直系继任，共 4 处引用）。
如需更高质量可用 `--model deepseek-ai/deepseek-v4-pro-0813`。